### PR TITLE
feat: Drop outputs of deprecated values

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ See [variables.tf] and [examples/] for details and use-cases.
 | <a name="output_html_url"></a> [html\_url](#output\_html\_url) | URL to the repository on the web. |
 | <a name="output_http_clone_url"></a> [http\_clone\_url](#output\_http\_clone\_url) | URL that can be provided to git clone to clone the repository via HTTPS. |
 | <a name="output_issue_labels"></a> [issue\_labels](#output\_issue\_labels) | A map of issue labels keyed by label input id or name. |
-| <a name="output_repository"></a> [repository](#output\_repository) | All attributes and arguments as returned by the github\_repository resource. |
+| <a name="output_repository"></a> [repository](#output\_repository) | Non-deprecated attributes of the github\_repository resource. |
 | <a name="output_secrets"></a> [secrets](#output\_secrets) | List of secrets available. |
 | <a name="output_ssh_clone_url"></a> [ssh\_clone\_url](#output\_ssh\_clone\_url) | URL that can be provided to git clone to clone the repository via SSH. |
 | <a name="output_webhooks"></a> [webhooks](#output\_webhooks) | All attributes and arguments as returned by the github\_repository\_webhook resource. |

--- a/README.md
+++ b/README.md
@@ -87,20 +87,20 @@ See [variables.tf] and [examples/] for details and use-cases.
 ### Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | >= 6.9.1 |
 
 ### Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_github"></a> [github](#provider\_github) | >= 6.9.1 |
 
 ### Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [github_actions_environment_variable.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_variable) | resource |
 | [github_actions_secret.repository_secret](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_actions_variable.repository_variable](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_variable) | resource |
@@ -127,7 +127,7 @@ See [variables.tf] and [examples/] for details and use-cases.
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_admin_collaborators"></a> [admin\_collaborators](#input\_admin\_collaborators) | (Optional) A list of users to add as collaborators granting them admin (full) permission. | `list(string)` | `[]` | no |
 | <a name="input_admin_team_ids"></a> [admin\_team\_ids](#input\_admin\_team\_ids) | (Optional) A list of teams (by id) to grant admin (full) permission to. | `list(string)` | `[]` | no |
 | <a name="input_admin_teams"></a> [admin\_teams](#input\_admin\_teams) | (Optional) A list of teams (by name/slug) to grant admin (full) permission to. | `list(string)` | `[]` | no |
@@ -154,7 +154,6 @@ See [variables.tf] and [examples/] for details and use-cases.
 | <a name="input_environments"></a> [environments](#input\_environments) | n/a | <pre>map(object({<br/>    reviewer_teams = optional(list(string), [])<br/>    reviewer_users = optional(list(string), [])<br/>    deployment_branch_policy = optional(object({<br/>      protected_branches     = bool<br/>      custom_branch_policies = optional(bool)<br/>    }))<br/>    branch_patterns     = optional(list(string), [])<br/>    variables           = optional(map(string), {})<br/>    wait_timer          = optional(number)<br/>    prevent_self_review = optional(bool)<br/>  }))</pre> | `{}` | no |
 | <a name="input_extra_topics"></a> [extra\_topics](#input\_extra\_topics) | (Optional) The list of additional topics of the repository. (Default: []) | `list(string)` | `[]` | no |
 | <a name="input_gitignore_template"></a> [gitignore\_template](#input\_gitignore\_template) | (Optional) Use the name of the template without the extension. For example, Haskell. Available templates: https://github.com/github/gitignore | `string` | `null` | no |
-| <a name="input_has_downloads"></a> [has\_downloads](#input\_has\_downloads) | (Optional) Set to true to enable the (deprecated) downloads features on the repository. (Default: false) | `bool` | `null` | no |
 | <a name="input_has_issues"></a> [has\_issues](#input\_has\_issues) | (Optional) Set to true to enable the GitHub Issues features on the repository. (Default: false) | `bool` | `null` | no |
 | <a name="input_has_wiki"></a> [has\_wiki](#input\_has\_wiki) | (Optional) Set to true to enable the GitHub Wiki features on the repository. (Default: false) | `bool` | `null` | no |
 | <a name="input_homepage_url"></a> [homepage\_url](#input\_homepage\_url) | (Optional) The website of the repository. | `string` | `null` | no |
@@ -197,7 +196,7 @@ See [variables.tf] and [examples/] for details and use-cases.
 ### Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_app_installations"></a> [app\_installations](#output\_app\_installations) | A map of deploy app installations keyed by installation id. |
 | <a name="output_branches"></a> [branches](#output\_branches) | A map of branch objects keyed by branch name. |
 | <a name="output_collaborators"></a> [collaborators](#output\_collaborators) | A map of collaborator objects keyed by collaborator.name. |

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,6 @@ locals {
   private_visibility     = local.private ? "private" : "public"
   visibility             = var.visibility == null ? lookup(var.defaults, "visibility", local.private_visibility) : var.visibility
   has_issues             = var.has_issues == null ? lookup(var.defaults, "has_issues", false) : var.has_issues
-  has_downloads          = var.has_downloads == null ? lookup(var.defaults, "has_downloads", false) : var.has_downloads
   has_wiki               = var.has_wiki == null ? lookup(var.defaults, "has_wiki", false) : var.has_wiki
   allow_merge_commit     = var.allow_merge_commit == null ? lookup(var.defaults, "allow_merge_commit", true) : var.allow_merge_commit
   allow_rebase_merge     = var.allow_rebase_merge == null ? lookup(var.defaults, "allow_rebase_merge", false) : var.allow_rebase_merge
@@ -110,7 +109,6 @@ resource "github_repository" "repository" {
   allow_auto_merge       = local.allow_auto_merge
   delete_branch_on_merge = local.delete_branch_on_merge
   is_template            = local.is_template
-  has_downloads          = local.has_downloads
   auto_init              = local.auto_init
   gitignore_template     = local.gitignore_template
   license_template       = local.license_template

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,8 +32,46 @@ output "git_clone_url" {
 # ----------------------------------------------------------------------------------------------------------------------
 
 output "repository" {
-  value       = github_repository.repository
-  description = "All attributes and arguments as returned by the github_repository resource."
+  value = {
+    id                          = github_repository.repository.id
+    node_id                     = github_repository.repository.node_id
+    repo_id                     = github_repository.repository.repo_id
+    name                        = github_repository.repository.name
+    full_name                   = github_repository.repository.full_name
+    description                 = github_repository.repository.description
+    visibility                  = github_repository.repository.visibility
+    homepage_url                = github_repository.repository.homepage_url
+    html_url                    = github_repository.repository.html_url
+    ssh_clone_url               = github_repository.repository.ssh_clone_url
+    http_clone_url              = github_repository.repository.http_clone_url
+    git_clone_url               = github_repository.repository.git_clone_url
+    svn_url                     = github_repository.repository.svn_url
+    primary_language            = github_repository.repository.primary_language
+    has_issues                  = github_repository.repository.has_issues
+    has_wiki                    = github_repository.repository.has_wiki
+    is_template                 = github_repository.repository.is_template
+    allow_merge_commit          = github_repository.repository.allow_merge_commit
+    allow_rebase_merge          = github_repository.repository.allow_rebase_merge
+    allow_squash_merge          = github_repository.repository.allow_squash_merge
+    allow_update_branch         = github_repository.repository.allow_update_branch
+    allow_auto_merge            = github_repository.repository.allow_auto_merge
+    delete_branch_on_merge      = github_repository.repository.delete_branch_on_merge
+    auto_init                   = github_repository.repository.auto_init
+    gitignore_template          = github_repository.repository.gitignore_template
+    license_template            = github_repository.repository.license_template
+    archived                    = github_repository.repository.archived
+    archive_on_destroy          = github_repository.repository.archive_on_destroy
+    topics                      = github_repository.repository.topics
+    web_commit_signoff_required = github_repository.repository.web_commit_signoff_required
+    squash_merge_commit_title   = github_repository.repository.squash_merge_commit_title
+    squash_merge_commit_message = github_repository.repository.squash_merge_commit_message
+    merge_commit_title          = github_repository.repository.merge_commit_title
+    merge_commit_message        = github_repository.repository.merge_commit_message
+    pages                       = github_repository.repository.pages
+    security_and_analysis       = github_repository.repository.security_and_analysis
+    template                    = github_repository.repository.template
+  }
+  description = "Non-deprecated attributes of the github_repository resource."
 }
 
 output "branches" {

--- a/variables.tf
+++ b/variables.tf
@@ -102,12 +102,6 @@ variable "delete_branch_on_merge" {
   default     = null
 }
 
-variable "has_downloads" {
-  description = "(Optional) Set to true to enable the (deprecated) downloads features on the repository. (Default: false)"
-  type        = bool
-  default     = null
-}
-
 variable "auto_init" {
   description = "(Optional) Wether or not to produce an initial commit in the repository. (Default: true)"
   type        = bool


### PR DESCRIPTION
Note this is a breaking change for any caller accessing `module.X.repository.private`, `.default_branch`, `.vulnerability_alerts`, or `.ignore_vulnerability_alerts_during_read`